### PR TITLE
setpriv only drop capabilities supported by kernel

### DIFF
--- a/webthings-gateway.sh
+++ b/webthings-gateway.sh
@@ -10,12 +10,17 @@ if [ ! -d "/etc/webthings-gateway" ]; then
   chown -R webthings:webthings "/etc/webthings-gateway"
 fi
 
+# WORKAROUND for `setpriv: libcap-ng is too old for "all" caps`, previously "-all" was used here
+# create a list to drop all capabilities supported by current kernel
+cap_prefix="-cap_"
+caps="$cap_prefix$(seq -s ",$cap_prefix" 0 $(cat /proc/sys/kernel/cap_last_cap))"
+
 cd /opt/webthings-gateway
 setpriv \
   --reuid=webthings \
   --regid=webthings \
   --init-groups \
-  --inh-caps=-all \
+  --inh-caps=$caps \
   node build/gateway.js
 
 # vim:set ts=2 sw=2 et ft=sh:


### PR DESCRIPTION
Workaround for #4 

If setpriv and its dependencies are built with kernel headers which don't list a certain capability, but are used on a system where that capability is available, any command line option related to capabilities using all gets the following error message:
setpriv: libcap-ng is too old for "all" caps

cat /proc/sys/kernel/cap_last_cap returns the last cap index (the last/highest capability index supported by the currently running kernel), so a list is generated using seq that looks like: -cap_0,...,-cap_N with N being the last cap index and ... being the rest of the items.